### PR TITLE
Add types export for nodenext module resolution

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -8,8 +8,14 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.umd.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.es.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.umd.js"
+      }
     }
   },
   "scripts": {


### PR DESCRIPTION
When using "moduleResolution": "NodeNext" in your tsconfig, typescript only looks at the exports field of the package json, and fails to find the .d.ts file if it's not referenced there since it doesn't look at the "types" property.

Adding the types mapping to exports is fully backwards compatible with the older module resolution strategy.